### PR TITLE
Remove toilets and guest_house from canonical PBF filter

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -594,15 +594,15 @@ oi_download_pbf() {
 oi_canonical_filter_args() {
   cat <<'EOF'
 n/highway=motorway_junction
-n/amenity=fuel,restaurant,fast_food,cafe,toilets,charging_station
-n/tourism=hotel,motel,guest_house
+n/amenity=fuel,restaurant,fast_food,cafe,charging_station
+n/tourism=hotel,motel
 n/shop=gas
 n/cuisine
 n/highway=rest_area,services
 w/highway=construction
 w/highway=motorway,motorway_link,trunk,trunk_link,rest_area,services
-w/amenity=fuel,restaurant,fast_food,cafe,toilets,charging_station
-w/tourism=hotel,motel,guest_house
+w/amenity=fuel,restaurant,fast_food,cafe,charging_station
+w/tourism=hotel,motel
 w/shop=gas
 w/cuisine
 EOF


### PR DESCRIPTION
## Summary
- Remove `amenity=toilets` from n/ and w/ filter lines — filtered out at derive.sql line 353, dead weight in the import
- Remove `tourism=guest_house` from n/ and w/ filter lines — not used by Pike, not relevant for interstate travelers

Remaining 5 active POI categories:
- **gas**: amenity=fuel, shop=gas
- **food**: amenity=restaurant,fast_food,cafe + cuisine tag
- **lodging**: tourism=hotel,motel
- **restArea**: highway=rest_area
- **evCharging**: amenity=charging_station

OI-specific tags (highway=services, highway=construction, highway=motorway_junction) are unchanged.

## Test plan
- [ ] Verify canonical filter args output matches expected 5 categories
- [ ] Next release build should produce smaller canonical PBF (fewer filtered objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)