### PR TITLE
fix: include unnamed rest area POIs in exit-POI linkage

### DIFF
--- a/schema/derive.sql
+++ b/schema/derive.sql
@@ -302,8 +302,16 @@ SELECT
     src.osm_id,
     NULL::text AS state,
     src.category,
-    src.name,
-    COALESCE(NULLIF(src.display_name, ''), src.name) AS display_name,
+    CASE
+        WHEN COALESCE(NULLIF(src.name, ''), '') = '' AND src.category = 'restArea'
+        THEN 'Rest Area'
+        ELSE src.name
+    END AS name,
+    COALESCE(
+        NULLIF(src.display_name, ''),
+        NULLIF(src.name, ''),
+        CASE WHEN src.category = 'restArea' THEN 'Rest Area' END
+    ) AS display_name,
     src.brand,
     src.geom,
     src.tags_json
@@ -351,7 +359,7 @@ FROM (
      AND ST_DWithin(e.geom::geography, p.geom::geography, 800.0)
     WHERE p.category IS NOT NULL
       AND p.category <> 'restroom'
-      AND LOWER(TRIM(COALESCE(NULLIF(p.display_name, ''), NULLIF(p.name, ''), 'Unknown'))) <> 'unknown'
+      AND (p.category = 'restArea' OR LOWER(TRIM(COALESCE(NULLIF(p.display_name, ''), NULLIF(p.name, ''), 'Unknown'))) <> 'unknown')
       AND NOT EXISTS (
           SELECT 1
           FROM exit_poi_reachability prior


### PR DESCRIPTION
## Summary
- State rest areas in OSM are often tagged `highway=rest_area` with no `name`. The derive filter excluded POIs whose name resolved to "Unknown", dropping **1,681 nameless rest area POIs** and leaving **1,256 exits** without any rest area services.
- Default nameless `restArea` POIs to name "Rest Area" in the `pois` table insert
- Exempt `restArea` category from the unknown-name filter in `exit_poi_candidates`

## Test plan
- [ ] Re-run derive on the OI database
- [ ] Verify `exit_poi_candidates` now links nameless rest area POIs (e.g., `way/477230288` near I-26 SC)
- [ ] Export pack and confirm rest area exits that previously had 0 POIs now have services
- [ ] Spot-check I-95 FL rest area (`node/111662043`) which had 0 POIs before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)