### PR TITLE
fix: prevent operator tag from becoming rest area POI name

### DIFF
--- a/schema/derive.sql
+++ b/schema/derive.sql
@@ -303,15 +303,25 @@ SELECT
     NULL::text AS state,
     src.category,
     CASE
-        WHEN COALESCE(NULLIF(src.name, ''), '') = '' AND src.category = 'restArea'
+        WHEN src.category = 'restArea' AND (
+            COALESCE(NULLIF(src.name, ''), '') = ''
+            OR (COALESCE(src.tags_json->>'name', '') = ''
+                AND COALESCE(src.tags_json->>'brand', '') = '')
+        )
         THEN 'Rest Area'
         ELSE src.name
     END AS name,
-    COALESCE(
-        NULLIF(src.display_name, ''),
-        NULLIF(src.name, ''),
-        CASE WHEN src.category = 'restArea' THEN 'Rest Area' END
-    ) AS display_name,
+    CASE
+        WHEN src.category = 'restArea' AND (
+            COALESCE(src.tags_json->>'name', '') = ''
+            AND COALESCE(src.tags_json->>'brand', '') = '')
+        THEN 'Rest Area'
+        ELSE COALESCE(
+            NULLIF(src.display_name, ''),
+            NULLIF(src.name, ''),
+            CASE WHEN src.category = 'restArea' THEN 'Rest Area' END
+        )
+    END AS display_name,
     src.brand,
     src.geom,
     src.tags_json

--- a/schema/osm2pgsql/openinterstate.lua
+++ b/schema/osm2pgsql/openinterstate.lua
@@ -125,10 +125,13 @@ function osm2pgsql.process_node(object)
 
     local cat = classify_poi(tags)
     if cat ~= nil then
-        local display_name = tags.brand or tags.name or tags.operator
+        -- operator fallback excluded: operator tags (e.g. "Florida Department
+        -- of Transportation") are not user-facing names.  Raw tags are stored
+        -- in the tags jsonb column for derive-time access if needed.
+        local display_name = tags.brand or tags.name
         poi_nodes:insert({
             category = cat,
-            name = tags.name or tags.brand or tags.operator,
+            name = tags.name or tags.brand,
             display_name = display_name,
             brand = tags.brand,
             tags = tags,
@@ -172,10 +175,10 @@ function osm2pgsql.process_way(object)
             way_geom = object:as_linestring()
         end
         if way_geom ~= nil then
-            local display_name = tags.brand or tags.name or tags.operator
+            local display_name = tags.brand or tags.name
             poi_ways:insert({
                 category = cat,
-                name = tags.name or tags.brand or tags.operator,
+                name = tags.name or tags.brand,
                 display_name = display_name,
                 brand = tags.brand,
                 tags = tags,


### PR DESCRIPTION
## Summary
- Rest area POIs in Florida (and potentially other states) displayed "Florida Department of Transportation" instead of "Rest Area" because the osm2pgsql lua config fell back to the `operator` tag when no `name` or `brand` tag exists
- **derive.sql**: When a restArea POI has no OSM `name` or `brand` tags (checked via `tags_json`), force name/display_name to "Rest Area" — this fixes the current data without requiring a PBF re-import
- **openinterstate.lua**: Remove `operator` fallback from name/display_name fields — prevents the issue at the source on next PBF import

## Affected exits
19 Florida rest area POIs across I-4, I-75, I-95, I-275 were showing "Florida Department of Transportation" as their name. After this fix they'll correctly show "Rest Area".

## Test plan
- [ ] Run derive + export pipeline
- [ ] Verify FDOT rest area POIs now have name="Rest Area" in the pack
- [ ] Verify correctly-named rest areas (e.g. I-10 FL "Jefferson County Rest Area Eastbound") are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)