### PR TITLE
Add park and dog park POI categories

### DIFF
--- a/schema/derive.sql
+++ b/schema/derive.sql
@@ -349,7 +349,8 @@ FROM (
         ) AS rank
     FROM exits e
     JOIN pois p
-      ON p.geom && ST_Expand(e.geom, 0.024)
+      ON p.geom && ST_Expand(e.geom,
+           CASE WHEN p.category IN ('park', 'dogPark') THEN 0.024 ELSE 0.012 END)
      AND ST_DWithin(e.geom::geography, p.geom::geography,
            CASE WHEN p.category IN ('park', 'dogPark') THEN 1600.0 ELSE 800.0 END)
     WHERE p.category IS NOT NULL

--- a/schema/derive.sql
+++ b/schema/derive.sql
@@ -349,11 +349,12 @@ FROM (
         ) AS rank
     FROM exits e
     JOIN pois p
-      ON p.geom && ST_Expand(e.geom, 0.012)
-     AND ST_DWithin(e.geom::geography, p.geom::geography, 800.0)
+      ON p.geom && ST_Expand(e.geom, 0.024)
+     AND ST_DWithin(e.geom::geography, p.geom::geography,
+           CASE WHEN p.category IN ('park', 'dogPark') THEN 1600.0 ELSE 800.0 END)
     WHERE p.category IS NOT NULL
       AND p.category <> 'restroom'
-      AND (p.category = 'restArea' OR LOWER(TRIM(COALESCE(NULLIF(p.display_name, ''), NULLIF(p.name, ''), 'Unknown'))) <> 'unknown')
+      AND (p.category IN ('restArea', 'park', 'dogPark') OR LOWER(TRIM(COALESCE(NULLIF(p.display_name, ''), NULLIF(p.name, ''), 'Unknown'))) <> 'unknown')
       AND NOT EXISTS (
           SELECT 1
           FROM exit_poi_reachability prior

--- a/schema/osm2pgsql/openinterstate.lua
+++ b/schema/osm2pgsql/openinterstate.lua
@@ -49,6 +49,7 @@ local function classify_poi(tags)
     local tourism = tags.tourism or ""
     local highway = tags.highway or ""
     local shop = tags.shop or ""
+    local leisure = tags.leisure or ""
 
     if amenity == "fuel" or shop == "gas" then
         return "gas"
@@ -67,6 +68,12 @@ local function classify_poi(tags)
     end
     if amenity == "charging_station" then
         return "evCharging"
+    end
+    if leisure == "dog_park" then
+        return "dogPark"
+    end
+    if leisure == "park" then
+        return "park"
     end
     return nil
 end


### PR DESCRIPTION
## Summary
- Add `park` (leisure=park) and `dogPark` (leisure=dog_park) categories to the POI pipeline
- Use 1600m radius for park/dogPark exit candidates (vs 800m for other categories)
- Add park/dogPark to name-filter exception list (unnamed parks aren't dropped)

## Test plan
- [ ] Run import + derive and check counts: `SELECT category, COUNT(*) FROM exit_poi_candidates WHERE category IN ('park','dogPark') GROUP BY category;`
- [ ] Verify parks appear in API responses for exits near known parks

🤖 Generated with [Claude Code](https://claude.com/claude-code)