### PR TITLE
Add park and dogPark POI categories

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -585,12 +585,14 @@ n/tourism=hotel,motel
 n/shop=gas
 n/cuisine
 n/highway=rest_area,services
+n/leisure=park,dog_park
 w/highway=construction
 w/highway=motorway,motorway_link,trunk,trunk_link,rest_area,services
 w/amenity=fuel,restaurant,fast_food,cafe,charging_station
 w/tourism=hotel,motel
 w/shop=gas
 w/cuisine
+w/leisure=park,dog_park
 EOF
 }
 

--- a/schema/derive.sql
+++ b/schema/derive.sql
@@ -365,11 +365,13 @@ FROM (
         ) AS rank
     FROM exits e
     JOIN pois p
-      ON p.geom && ST_Expand(e.geom, 0.012)
-     AND ST_DWithin(e.geom::geography, p.geom::geography, 800.0)
+      ON p.geom && ST_Expand(e.geom,
+           CASE WHEN p.category IN ('park', 'dogPark') THEN 0.024 ELSE 0.012 END)
+     AND ST_DWithin(e.geom::geography, p.geom::geography,
+           CASE WHEN p.category IN ('park', 'dogPark') THEN 1600.0 ELSE 800.0 END)
     WHERE p.category IS NOT NULL
       AND p.category <> 'restroom'
-      AND (p.category = 'restArea' OR LOWER(TRIM(COALESCE(NULLIF(p.display_name, ''), NULLIF(p.name, ''), 'Unknown'))) <> 'unknown')
+      AND (p.category IN ('restArea', 'park', 'dogPark') OR LOWER(TRIM(COALESCE(NULLIF(p.display_name, ''), NULLIF(p.name, ''), 'Unknown'))) <> 'unknown')
       AND NOT EXISTS (
           SELECT 1
           FROM exit_poi_reachability prior

--- a/schema/osm2pgsql/openinterstate.lua
+++ b/schema/osm2pgsql/openinterstate.lua
@@ -49,6 +49,7 @@ local function classify_poi(tags)
     local tourism = tags.tourism or ""
     local highway = tags.highway or ""
     local shop = tags.shop or ""
+    local leisure = tags.leisure or ""
 
     if amenity == "fuel" or shop == "gas" then
         return "gas"
@@ -67,6 +68,12 @@ local function classify_poi(tags)
     end
     if amenity == "charging_station" then
         return "evCharging"
+    end
+    if leisure == "dog_park" then
+        return "dogPark"
+    end
+    if leisure == "park" then
+        return "park"
     end
     return nil
 end


### PR DESCRIPTION
## Summary
- Adds `park` (leisure=park) and `dogPark` (leisure=dog_park) as new POI categories in the osm2pgsql Lua mapping
- Uses 1600m search radius for park/dogPark in derive.sql (vs 800m for other categories), with category-specific bounding box envelope
- Adds leisure tags to the osmium prefilter so park features survive the canonical filter

## Test plan
- [ ] Run a full import + derive and verify park/dogPark POIs appear in `pois` table
- [ ] Confirm `exit_poi_candidates` contains park/dogPark entries with distances up to 1600m
- [ ] Verify existing categories (gas, food, lodging, etc.) still use the 800m radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)